### PR TITLE
Fix MinGW build issues on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tools/encuid2/swtg_nonsense.patch text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code
+.vscode/

--- a/tools/encuid2/encuid2.c
+++ b/tools/encuid2/encuid2.c
@@ -5,7 +5,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
-#include <endian.h>
 #include <unistd.h>
 #include <inttypes.h>
 #include <assert.h>


### PR DESCRIPTION
- Remove deprecated <endian.h> include from `encuid2.c`
- Enforce LF line endings via .gitattributes to prevent patch corruption on Git for Windows
- Ignore VS Code workspace files